### PR TITLE
update list of environment values

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ It is a good idea to check what region you are in every time you log into the co
 We implemented a tagging standard at BYU for organization and automation efforts. The tagging standard is described below...
 
 * **env:**
-     * **tst:** For training, learning, or experimental efforts (should be used for the byu-trn account).
-     * **dev:** A development system.
-     * **dev-noshutdown:** A development system that should not be part of our off-hours scheduling.
+     * **tst:** For training, learning, or experimental efforts (should be used for the byu-trn account)
+     * **dev:** A development system
      * **stg:** Staging systems used for QA and User Acceptance Testing
-     * **stg-noshutdown:** A staging system that should not be part par of our off-hours scheduling.
      * **prd:** Production
+     * **cpy:** Copies of production systems (typically for business users or API consumers to experiment)
 
 
 * **data-sensitivity:**


### PR DESCRIPTION
Automatic shutdown was an idea that was discarded. We don't need those tag values anymore.
Adding "cpy" environment as an option.
